### PR TITLE
Feature/85 Adicionar tipo de Árbitro

### DIFF
--- a/src/Components/DataEntry/FieldWithIcon/FieldWithIcon.jsx
+++ b/src/Components/DataEntry/FieldWithIcon/FieldWithIcon.jsx
@@ -43,7 +43,6 @@ export default function FieldWithIcon(props) {
                 {...field}
                 {...optionalProps}
                 className="field-with-icon-input"
-                id={id}
                 placeholder={placeholder}
                 onChange={fieldWithIconOnChange(form)}
                 required

--- a/src/Services/api.js
+++ b/src/Services/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: 'http://localhost:3000',
+  baseURL: 'http://localhost:3333',
 });
 
 export default api;

--- a/src/Views/Dashboard/Admin/CadastroArbitrosForm/CadastroArbitrosForm.css
+++ b/src/Views/Dashboard/Admin/CadastroArbitrosForm/CadastroArbitrosForm.css
@@ -19,33 +19,47 @@
   cursor: pointer;
 }
 
+.formulario-cadastro-arbitros > div {
+  display: flex;
+  margin-bottom: 20px;
+  flex: 0 1;
+}
+
+.formulario-cadastro-arbitros > div:nth-last-child(2) {
+  flex: 1 1;
+}
+
 .formulario-cadastro-arbitros > div > div {
   margin-top: 0;
   flex: 1;
   min-width: 230px;
-}
-
-.formulario-cadastro-arbitros > div {
-  display: flex;
-}
-
-.formulario-cadastro-arbitros > div > div:first-child {
   margin-right: 60px;
+}
+
+.formulario-cadastro-arbitros > div > div:last-child {
+  margin-right: 0;
+}
+
+.formulario-cadastro-arbitros > div > div > span {
+  margin-left: 20px;
+  color: #626262;
+  font-weight: 500;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.formulario-cadastro-arbitros > div > div > .ant-radio-group {
+  margin-top: 7px;
 }
 
 @media (max-width: 900px) {
   .formulario-cadastro-arbitros > div {
     flex-direction: column;
-    flex: 1;
     height: 100%;
   }
 
   .formulario-cadastro-arbitros > div > div {
     flex: 0;
     margin-bottom: 20px;
-  }
-
-  .formulario-cadastro-arbitros > div > div:first-child {
     margin-right: 0;
   }
 
@@ -66,8 +80,4 @@
 }
 .formulario-cadastro-arbitros button:active {
   background: #e8ab58 !important;
-}
-
-[ant-click-animating-without-extra-node='true']::after {
-  --antd-wave-shadow-color: #ffc375;
 }

--- a/src/Views/Dashboard/Admin/CadastroArbitrosForm/CadastroArbitrosForm.jsx
+++ b/src/Views/Dashboard/Admin/CadastroArbitrosForm/CadastroArbitrosForm.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Button, notification } from 'antd';
+import { Button, Radio, notification } from 'antd';
+import { Field } from 'formik';
 import { faUser, faEnvelope } from '@fortawesome/free-solid-svg-icons';
 import './CadastroArbitrosForm.css';
 
@@ -14,10 +15,14 @@ import api from '../../../../Services/api';
 async function registerJudge(event, values, setFieldValue) {
   event.preventDefault();
 
-  const { name, email } = values;
+  const { name, email, JudgeType } = values;
 
   try {
-    const response = await api.post('/createJudge', { name, email });
+    const response = await api.post('/createJudge', {
+      name,
+      email,
+      judge_type: JudgeType,
+    });
     const { password } = response.data;
     notification.success({
       message: (
@@ -37,6 +42,7 @@ async function registerJudge(event, values, setFieldValue) {
     });
     setFieldValue('name', '');
     setFieldValue('email', '');
+    setFieldValue('JudgeType', 'Execution and Difficulty');
   } catch (err) {
     if (err.response) {
       notification.error({ message: err.response.data });
@@ -67,6 +73,7 @@ export default function CadastroArbitrosForm(props) {
           <div>
             <FieldWithIcon
               name="name"
+              type="text"
               placeholder="Insira o nome"
               id="InputDoNomeDoArbitro"
               labeltext="Nome do árbitro:"
@@ -83,6 +90,24 @@ export default function CadastroArbitrosForm(props) {
               labeltext="E-mail do árbitro:"
               icon={faEnvelope}
             />
+          </div>
+        </div>
+
+        <div>
+          <div>
+            <span>Avalia:</span>
+            <br />
+            <Field name="JudgeType">
+              {({ field }) => (
+                <Radio.Group {...field} name="JudgeType" size="large">
+                  <Radio.Button value="Execution and Difficulty">
+                    Execução e Dificuldade
+                  </Radio.Button>
+                  <Radio.Button value="Execution">Execução</Radio.Button>
+                  <Radio.Button value="Difficulty">Dificuldade</Radio.Button>
+                </Radio.Group>
+              )}
+            </Field>
           </div>
         </div>
 

--- a/src/Views/Dashboard/Admin/CadastroArbitrosForm/index.js
+++ b/src/Views/Dashboard/Admin/CadastroArbitrosForm/index.js
@@ -2,7 +2,7 @@ import { withFormik } from 'formik';
 import CadastroArbitrosForm from './CadastroArbitrosForm';
 
 function mapPropsToValues() {
-  return { name: '', email: '' };
+  return { name: '', email: '', JudgeType: 'Execution and Difficulty' };
 }
 
 export default withFormik({ mapPropsToValues })(CadastroArbitrosForm);


### PR DESCRIPTION
## Tipo da mudança

- [ ] Resolver Bug
- [X] Adicionar nova funcionalidade
- [ ] Atualizar documentação

## Descrição das mudanças
O cadastro de árbitros por formulário agora possui um [Radio Group](https://ant.design/components/radio/) para selecionar o tipo de árbitro.

Para este PR funcionar é necessário utilizar a branch do PR realizado no backend também.